### PR TITLE
easycodef, connector 전체 개선

### DIFF
--- a/lib/accesstoken.js
+++ b/lib/accesstoken.js
@@ -1,13 +1,40 @@
+const {
+  SERVICE_TYPE_SANDBOX,
+  SERVICE_TYPE_DEMO,
+  SERVICE_TYPE_API,
+} = require('./constant');
+
 /**
  *  서비스 별 토큰 관리 클래스
  */
-let accesstoken = new Map();
-let tokenmap = {
-  setToken: function (serviceType, accessToken) {
-    accesstoken.set(serviceType, accessToken);
-  },
-  getToken: function (serviceType) {
-    return accesstoken.get(serviceType);
-  },
+module.exports = class accessToken {
+  constructor() {
+    this.sandbox = '';
+    this.demo = '';
+    this.api = '';
+  }
+
+  setToken(serviceType, accessToken) {
+    switch (serviceType) {
+      case SERVICE_TYPE_API:
+        this.api = accessToken;
+        break;
+      case SERVICE_TYPE_DEMO:
+        this.demo = accessToken;
+        break;
+      default:
+        this.sandbox = accessToken;
+    }
+  }
+
+  getToken(serviceType) {
+    switch (serviceType) {
+      case SERVICE_TYPE_API:
+        return this.api;
+      case SERVICE_TYPE_DEMO:
+        return this.demo;
+      default:
+        return this.sandbox;
+    }
+  }
 };
-module.exports = tokenmap;

--- a/lib/connector.js
+++ b/lib/connector.js
@@ -1,247 +1,161 @@
-const easyCodefConstant = require("./constant");
-const easyCodefMsg = require("./messageconstant");
+const { OAUTH_DOMAIN, GET_TOKEN, REPEAT_COUNT } = require('./constant');
+const easyCodefMsg = require('./messageconstant');
 const easyCodefMsgGetResponse = easyCodefMsg.getResponseMessageConstant;
-const request = require("request");
-let easyCodefAcessToken = require("./accesstoken");
+const request = require('request');
 
 /**
  *  CODEF API 통신요청
- * @param properties
+ * @param codef
  * @param serviceType
  * @param productURL
  * @param param
  * @returns {Promise<unknown>}
  */
-function execute(properties, serviceType, productURL, param) {
-  /**
-   * CODEF 상품 요청
-   * @param token
-   * @returns {Promise<unknown>}
-   */
-  let requestProduct = function (token) {
-    return new Promise(function (resolve, reject) {
-      let options = {
-        url: properties.getProductRequestURL(serviceType, productURL),
-        method: "POST",
-        headers: {
-          "Content-Type": "application/x-www-form-urlencoded",
-          Authorization: "Bearer " + token,
-        },
-      };
+async function execute(codef, serviceType, productURL, param) {
+  // 토큰 셋팅
+  await setToken(serviceType, codef);
+  // 상품 요청
+  const result = await requestProduct(serviceType, productURL, codef, param);
 
-      request
-        .post(options, (error, response, body) => {
-          if (response) {
-            resolve(response);
-          }
-          if (error) {
-            reject(error);
-          }
-        })
-        .write(encodeURIComponent(JSON.stringify(param)));
-    });
-  };
+  let bodyError = JSON.parse(result).error;
+  if (bodyError === 'invalid_token') {
+    // 액세스 토큰 유효기간 만료시 재 요청
+    codef.setAccessToken(serviceType, '');
+    return await execute(codef, serviceType, productURL, param);
+  }
 
-  /**
-   *  CODEF 토큰 발급 > 상품 요청
-   * @returns {Promise<{result: *, data: {}}|string|*>}
-   */
-  let productWorker = async function () {
-    let token;
+  return result;
+}
 
-    for (let i = 0; i < easyCodefConstant.REPEAT_COUNT; i++) {
-      try {
-        token = await requestToken(serviceType, properties);
-        break;
-      } catch (e) {}
-    }
-
-    let response;
-    try {
-      response = await requestProduct(token);
-    } catch (error) {
-      response = error;
-    }
-
-    try {
-      let bodyJSON = response.body
-        ? decodeString(response.body)
-        : response.body;
-
-      let bodyError = JSON.parse(bodyJSON).error;
-      if (bodyError) {
-        if (bodyError == "invalid_token") {
-          // 액세스 토큰 유효기간 만료시
-          easyCodefAcessToken.setToken(serviceType, null);
-          // 토큰 재 요청
-          token = await requestToken(serviceType, properties);
-          try {
-            //+ 상품 재 요청.
-            response = await requestProduct(token);
-          } catch (error) {
-            response = error;
-          }
-          bodyJSON = response.body
-            ? decodeString(response.body)
-            : response.body;
-        }
-      }
-
-      // + 응답결과 처리
-      if (response.statusCode == 200) {
-        return bodyJSON;
-      } else {
-        switch (response.statusCode) {
-          case 401:
-            return easyCodefMsgGetResponse(
-              easyCodefMsg.UNAUTHORIZED.CODE,
-              easyCodefMsg.UNAUTHORIZED.MESSAGE
-            );
-            break;
-          case 403:
-            return easyCodefMsgGetResponse(
-              easyCodefMsg.FORBIDDEN.CODE,
-              easyCodefMsg.FORBIDDEN.MESSAGE
-            );
-            break;
-          case 404: // HTTP Status-Code 404: Not Found.
-            return easyCodefMsgGetResponse(
-              easyCodefMsg.NOT_FOUND.CODE,
-              easyCodefMsg.NOT_FOUND.MESSAGE
-            );
-            break;
-          default:
-            return easyCodefMsgGetResponse(
-              easyCodefMsg.SERVER_ERROR.CODE,
-              easyCodefMsg.SERVER_ERROR.MESSAGE
-            );
-        }
-      }
-    } catch (e) {
-      return easyCodefMsgGetResponse(
-        easyCodefMsg.LIBRARY_SENDER_ERROR.CODE,
-        easyCodefMsg.LIBRARY_SENDER_ERROR.MESSAGE,
-        e.message
-      );
-    }
-  };
-
+/**
+ * CODEF 상품 요청
+ * @param token
+ * @returns {Promise<unknown>}
+ */
+function requestProduct(serviceType, productURLPath, codef, param) {
   return new Promise(function (resolve, reject) {
-    if (!checkClientInfo(serviceType, properties)) {
-      resolve(
-        easyCodefMsgGetResponse(
-          easyCodefMsg.EMPTY_CLIENT_INFO.CODE,
-          easyCodefMsg.EMPTY_CLIENT_INFO.MESSAGE
-        )
-      );
-      return;
-    }
-    // 2.필수 항목 체크 - 퍼블릭 키
-    if (!checkPublicKey(properties)) {
-      resolve(
-        easyCodefMsgGetResponse(
-          easyCodefMsg.EMPTY_PUBLIC_KEY.CODE,
-          easyCodefMsg.EMPTY_PUBLIC_KEY.MESSAGE
-        )
-      );
-      return;
-    }
-    //+ 3. 상품 요청 - 응답
-    productWorker().then(function (response) {
-      resolve(response);
-    });
+    let options = createReqProductOptions(serviceType, productURLPath, codef);
+    request
+      .post(options, (error, response) => {
+        if (error) {
+          reject(error);
+        }
+
+        let result = '';
+        // + 응답결과 처리
+        if (response.statusCode === 200) {
+          result = response.body ? decodeString(response.body) : response.body;
+        } else {
+          result = getErrorMsgResult(response.statusCode);
+        }
+        resolve(result);
+      })
+      .write(encodeURIComponent(JSON.stringify(param)));
   });
 }
 
-module.exports.execute = execute;
+/**
+ * Response 상태 코드에 따라 에러 메시지 정보 가져오기
+ * @param {number} statusCode
+ */
+function getErrorMsgResult(statusCode) {
+  switch (statusCode) {
+    case 401:
+      return easyCodefMsgGetResponse(easyCodefMsg.UNAUTHORIZED);
+    case 403:
+      return easyCodefMsgGetResponse(easyCodefMsg.FORBIDDEN);
+    case 404: // HTTP Status-Code 404: Not Found.
+      return easyCodefMsgGetResponse(easyCodefMsg.NOT_FOUND);
+    default:
+      return easyCodefMsgGetResponse(easyCodefMsg.SERVER_ERROR);
+  }
+}
+
+/**
+ * 상품 요청 옵션 생성
+ *
+ * @param {SERVICE_TYPE} serviceType
+ * @param {string} productURLPath
+ * @param {string} token
+ */
+function createReqProductOptions(serviceType, productURLPath, codef) {
+  const options = {
+    url: codef.getProductRequestURL(serviceType, productURLPath),
+    headers: {
+      'Content-Type': 'application/json',
+    },
+  };
+
+  if (codef.getAccessToken(serviceType)) {
+    options.headers.Authorization = `Bearer ${codef.getAccessToken(
+      serviceType
+    )}`;
+  }
+
+  return options;
+}
+
+async function setToken(serviceType, codef) {
+  for (let i = 0; i < REPEAT_COUNT; i++) {
+    const token = await requestToken(serviceType, codef);
+    if (token) {
+      codef.setAccessToken(token);
+      break;
+    }
+  }
+}
 
 /**
  *  토큰발급 요청
  * @param serviceType
- * @param properties
+ * @param codef
  * @returns {Promise<unknown>}
  */
-function requestToken(serviceType, properties) {
-  return new Promise(function (resolve, reject) {
-    let clientID = easyCodefConstant.SANDBOX_CLIENT_ID;
-    let clientSecret = easyCodefConstant.SANDBOX_CLIENT_SECRET;
-
-    switch (serviceType) {
-      case easyCodefConstant.SERVICE_TYPE_API: // 정식
-        clientID = properties.CLIENT_ID;
-        clientSecret = properties.CLIENT_SECRET;
-        break;
-      case easyCodefConstant.SERVICE_TYPE_DEMO: // 데모
-        clientID = properties.DEMO_CLIENT_ID;
-        clientSecret = properties.DEMO_CLIENT_SECRET;
-        break;
-    }
-
-    let token = easyCodefAcessToken.getToken(serviceType);
+function requestToken(serviceType, codef) {
+  return new Promise((resolve, reject) => {
+    let token = codef.getAccessToken(serviceType);
     if (token) {
       resolve(token);
       return;
     }
-
-    let options = {
-      url: easyCodefConstant.OAUTH_DOMAIN + easyCodefConstant.GET_TOKEN,
-      method: "POST",
-      headers: {
-        Accept: "application/json",
-        "Content-Type": "application/x-www-form-urlencoded",
-        Authorization:
-          "Basic " +
-          Buffer.from(clientID + ":" + clientSecret).toString("base64"),
-      },
-    };
+    // 클라이언트 정보 조회
+    const { clientID, clientSecret } = codef.getClientInfo(serviceType);
+    // 옵션 셋팅
+    let options = createReqTokenOptions(clientID, clientSecret);
 
     request
-      .post(options, (error, response, body) => {
-        if (response) {
-          if (response.statusCode == 200) {
-            let token = JSON.parse(response.body).access_token;
-            easyCodefAcessToken.setToken(serviceType, token);
-            resolve(token);
-          }
-          reject(error);
+      .post(options, (err, response) => {
+        if (err) {
+          reject(err);
         }
-        if (error) {
-          reject(error);
+
+        if (response && response.statusCode === 200) {
+          let token = JSON.parse(response.body).access_token;
+          resolve(token);
+        } else {
+          reject(`Response status code ${response.statusCode}`);
         }
       })
-      .write("grant_type=client_credentials&scope=read");
+      .write('grant_type=client_credentials&scope=read');
   });
 }
-module.exports.requestToken = requestToken;
 
 /**
- * 서비스 타입에 따른 클라이언트 정보 설정 확인
- * @returns {boolean}
+ * 토큰 요청 옵션 생성
+ * @param {string} clientID
+ * @param {string} clientSecret
  */
-function checkClientInfo(serviceType, properties) {
-  switch (serviceType) {
-    case easyCodefConstant.SERVICE_TYPE_API: // 정식
-      return properties.CLIENT_ID && properties.CLIENT_SECRET;
-    case easyCodefConstant.SERVICE_TYPE_DEMO: // 데모
-      return properties.DEMO_CLIENT_ID && properties.DEMO_CLIENT_SECRET;
-    default:
-      // 샌드박스
-      return (
-        easyCodefConstant.SANDBOX_CLIENT_ID &&
-        easyCodefConstant.SANDBOX_CLIENT_SECRET
-      );
-  }
-}
-
-/**
- * PUBLIC_KEY 정보 설정 확인
- * @returns {boolean}
- */
-function checkPublicKey(properties) {
-  if (properties.PUBLIC_KEY) {
-    return true;
-  }
-  return false;
+function createReqTokenOptions(clientID, clientSecret) {
+  return {
+    url: OAUTH_DOMAIN + GET_TOKEN,
+    headers: {
+      Accept: 'application/json',
+      'Content-Type': 'application/x-www-form-urlencoded',
+      Authorization:
+        'Basic ' +
+        Buffer.from(clientID + ':' + clientSecret).toString('base64'),
+    },
+  };
 }
 
 /**
@@ -251,12 +165,14 @@ function checkPublicKey(properties) {
  */
 function decodeString(str) {
   try {
-    if (str.indexOf("+") > 0) {
-      return decodeURIComponent(decodeURI(str).replace(/\+/g, " "));
-    } else {
-      return decodeURIComponent(decodeURI(str));
-    }
+    return decodeURIComponent(decodeURI(str).replace(/\+/g, ' '));
   } catch (e) {
     return unescape(decodeURI(str));
   }
 }
+
+module.exports = {
+  execute,
+  requestProduct,
+  requestToken,
+};

--- a/lib/connector.js
+++ b/lib/connector.js
@@ -96,6 +96,10 @@ function createReqProductOptions(serviceType, productURLPath, codef) {
 }
 
 async function setToken(serviceType, codef) {
+  if (codef.getAccessToken(serviceType)) {
+    return;
+  }
+
   for (let i = 0; i < REPEAT_COUNT; i++) {
     const token = await requestToken(serviceType, codef);
     if (token) {

--- a/lib/easycodef.js
+++ b/lib/easycodef.js
@@ -1,28 +1,35 @@
-const easyCodefConstant = require("./constant");
-let easyCodefConnector = require("./connector");
-const easycodefProperties = require("./properties");
-let easyCodefProp = new easycodefProperties();
-let easyCodefAcessToken = require("./accesstoken");
+const easyCodefConstant = require('./constant');
+const easyCodefConnector = require('./connector');
+const EasycodefProperties = require('./properties');
+const EasyCodefAcessToken = require('./accesstoken');
+const {
+  getResponseMessageConstant,
+  EMPTY_CLIENT_INFO,
+  EMPTY_PUBLIC_KEY,
+} = require('./messageconstant');
 
 /**
  * 코드에프의 쉬운 사용을 위한 유틸 라이브러리 클래스
  */
 class Easycodef {
-  constructor() {}
+  constructor() {
+    this.properties = new EasycodefProperties();
+    this.accessToken = new EasyCodefAcessToken();
+  }
 
   /**
    * RSA 암호화를 위한 퍼블릭키 설정
    * @param key
    */
   setPublicKey(publickey) {
-    easyCodefProp.setPublicKey(publickey);
+    this.properties.setPublicKey(publickey);
   }
 
   /**
    *  RSA암호화를 위한 퍼블릭키
    */
   getPublicKey() {
-    return easyCodefProp.PUBLIC_KEY;
+    return this.properties.PUBLIC_KEY;
   }
 
   /**
@@ -31,7 +38,7 @@ class Easycodef {
    * @param realClientSecret
    */
   setClientInfo(clientID, clientSecret) {
-    easyCodefProp.setClientInfo(clientID, clientSecret);
+    this.properties.setClientInfo(clientID, clientSecret);
   }
 
   /**
@@ -40,7 +47,7 @@ class Easycodef {
    * @param demoClientSecret
    */
   setClientInfoForDemo(clientID, clientSecret) {
-    easyCodefProp.setDemoClientInfo(clientID, clientSecret);
+    this.properties.setDemoClientInfo(clientID, clientSecret);
   }
 
   /**
@@ -48,8 +55,43 @@ class Easycodef {
    * @param serviceType
    * @param token
    */
-  setServiceTypeToken(serviceType, token) {
-    easyCodefAcessToken.setToken(serviceType, token);
+  setAccessToken(serviceType, token) {
+    this.accessToken.setToken(serviceType, token);
+  }
+
+  /**
+   * 서비스별 토큰 가져오기
+   * @param serviceType
+   */
+  getAccessToken(serviceType) {
+    return this.accessToken.getToken(serviceType);
+  }
+
+  /**
+   * 클라이언트 정보 조회
+   * @param {*} serviceType
+   */
+  getClientInfo(serviceType) {
+    return this.properties.getClientInfo(serviceType);
+  }
+
+  /**
+   * 서비스 타입에 따른 클라이언트 정보 설정 확인
+   * @returns {boolean}
+   */
+  checkClientInfo(serviceType) {
+    const { clientID, clientSecret } = this.getClientInfo(serviceType);
+    return clientID && clientSecret;
+  }
+
+  /**
+   * 상품 요청 URL
+   * @param serviceType
+   * @param productURL
+   * @returns {string}
+   */
+  getProductRequestURL(serviceType, productURL) {
+    return this.properties.getProductRequestURL(serviceType, productURL);
   }
 
   /**
@@ -58,9 +100,18 @@ class Easycodef {
    * @param serviceType
    * @param parameterMap
    */
-  requestProduct(productURL, serviceType, param) {
-    return easyCodefConnector.execute(
-      easyCodefProp,
+  async requestProduct(productURL, serviceType, param) {
+    // 1.필수 항목 체크 - 클라이언트 정보
+    if (!this.checkClientInfo(serviceType, codef)) {
+      return getResponseMessageConstant(EMPTY_CLIENT_INFO);
+    }
+    // 2.필수 항목 체크 - 퍼블릭 키
+    if (!codef.getPublicKey()) {
+      return getResponseMessageConstant(EMPTY_PUBLIC_KEY);
+    }
+
+    return await easyCodefConnector.execute(
+      this,
       serviceType,
       productURL,
       param
@@ -71,8 +122,8 @@ class Easycodef {
    * 서비스별 (정식/데모/샌드박스)토큰발급 요청
    * @param serviceType
    */
-  requestToken(serviceType) {
-    return easyCodefConnector.requestToken(serviceType, easyCodefProp);
+  async requestToken(serviceType) {
+    return await easyCodefConnector.requestToken(serviceType, this);
   }
 
   /**
@@ -80,8 +131,8 @@ class Easycodef {
    * @param serviceType
    * @param paramMap
    */
-  getConnectedIdList(serviceType, param) {
-    return this.requestProduct(
+  async getConnectedIdList(serviceType, param) {
+    return await this.requestProduct(
       easyCodefConstant.GET_CID_LIST,
       serviceType,
       param
@@ -93,8 +144,8 @@ class Easycodef {
    * @param serviceType
    * @param paramMap
    */
-  createAccount(serviceType, param) {
-    return this.requestProduct(
+  async createAccount(serviceType, param) {
+    return await this.requestProduct(
       easyCodefConstant.CREATE_ACCOUNT,
       serviceType,
       param
@@ -106,8 +157,8 @@ class Easycodef {
    * @param serviceType
    * @param paramMap
    */
-  getAccountList(serviceType, param) {
-    return this.requestProduct(
+  async getAccountList(serviceType, param) {
+    return await this.requestProduct(
       easyCodefConstant.GET_ACCOUNT_LIST,
       serviceType,
       param
@@ -119,8 +170,8 @@ class Easycodef {
    * @param serviceType
    * @param param
    */
-  addAccount(serviceType, param) {
-    return this.requestProduct(
+  async addAccount(serviceType, param) {
+    return await this.requestProduct(
       easyCodefConstant.ADD_ACCOUNT,
       serviceType,
       param
@@ -132,8 +183,8 @@ class Easycodef {
    * @param serviceType
    * @param param
    */
-  deleteAccount(serviceType, param) {
-    return this.requestProduct(
+  async deleteAccount(serviceType, param) {
+    return await this.requestProduct(
       easyCodefConstant.DELETE_ACCOUNT,
       serviceType,
       param
@@ -145,12 +196,13 @@ class Easycodef {
    * @param serviceType
    * @param param
    */
-  updateAccount(serviceType, param) {
-    return this.requestProduct(
+  async updateAccount(serviceType, param) {
+    return await this.requestProduct(
       easyCodefConstant.UPDATE_ACCOUNT,
       serviceType,
       param
     );
   }
 }
+
 module.exports = Easycodef;

--- a/lib/easycodef.js
+++ b/lib/easycodef.js
@@ -100,7 +100,7 @@ class Easycodef {
    * @param serviceType
    * @param parameterMap
    */
-  async requestProduct(productURL, serviceType, param) {
+  requestProduct(productURL, serviceType, param) {
     // 1.필수 항목 체크 - 클라이언트 정보
     if (!this.checkClientInfo(serviceType, codef)) {
       return getResponseMessageConstant(EMPTY_CLIENT_INFO);
@@ -110,20 +110,15 @@ class Easycodef {
       return getResponseMessageConstant(EMPTY_PUBLIC_KEY);
     }
 
-    return await easyCodefConnector.execute(
-      this,
-      serviceType,
-      productURL,
-      param
-    );
+    return easyCodefConnector.execute(this, serviceType, productURL, param);
   }
 
   /**
    * 서비스별 (정식/데모/샌드박스)토큰발급 요청
    * @param serviceType
    */
-  async requestToken(serviceType) {
-    return await easyCodefConnector.requestToken(serviceType, this);
+  requestToken(serviceType) {
+    return easyCodefConnector.requestToken(serviceType, this);
   }
 
   /**
@@ -131,8 +126,8 @@ class Easycodef {
    * @param serviceType
    * @param paramMap
    */
-  async getConnectedIdList(serviceType, param) {
-    return await this.requestProduct(
+  getConnectedIdList(serviceType, param) {
+    return this.requestProduct(
       easyCodefConstant.GET_CID_LIST,
       serviceType,
       param
@@ -144,8 +139,8 @@ class Easycodef {
    * @param serviceType
    * @param paramMap
    */
-  async createAccount(serviceType, param) {
-    return await this.requestProduct(
+  createAccount(serviceType, param) {
+    return this.requestProduct(
       easyCodefConstant.CREATE_ACCOUNT,
       serviceType,
       param
@@ -157,8 +152,8 @@ class Easycodef {
    * @param serviceType
    * @param paramMap
    */
-  async getAccountList(serviceType, param) {
-    return await this.requestProduct(
+  getAccountList(serviceType, param) {
+    return this.requestProduct(
       easyCodefConstant.GET_ACCOUNT_LIST,
       serviceType,
       param
@@ -170,8 +165,8 @@ class Easycodef {
    * @param serviceType
    * @param param
    */
-  async addAccount(serviceType, param) {
-    return await this.requestProduct(
+  addAccount(serviceType, param) {
+    return this.requestProduct(
       easyCodefConstant.ADD_ACCOUNT,
       serviceType,
       param
@@ -183,8 +178,8 @@ class Easycodef {
    * @param serviceType
    * @param param
    */
-  async deleteAccount(serviceType, param) {
-    return await this.requestProduct(
+  deleteAccount(serviceType, param) {
+    return this.requestProduct(
       easyCodefConstant.DELETE_ACCOUNT,
       serviceType,
       param
@@ -196,8 +191,8 @@ class Easycodef {
    * @param serviceType
    * @param param
    */
-  async updateAccount(serviceType, param) {
-    return await this.requestProduct(
+  updateAccount(serviceType, param) {
+    return this.requestProduct(
       easyCodefConstant.UPDATE_ACCOUNT,
       serviceType,
       param

--- a/lib/messageconstant.js
+++ b/lib/messageconstant.js
@@ -1,67 +1,67 @@
 module.exports = {
   OK: {
-    CODE: "CF-00000",
-    MESSAGE: "성공",
+    CODE: 'CF-00000',
+    MESSAGE: '성공',
   },
   INVALID_JSON: {
-    CODE: "CF-00002",
-    MESSAGE: "json형식이 올바르지 않습니다.",
+    CODE: 'CF-00002',
+    MESSAGE: 'json형식이 올바르지 않습니다.',
   },
   INVALID_PARAMETER: {
-    CODE: "CF-00007",
-    MESSAGE: "요청 파라미터가 올바르지 않습니다.",
+    CODE: 'CF-00007',
+    MESSAGE: '요청 파라미터가 올바르지 않습니다.',
   },
   UNSUPPORTED_ENCODING: {
-    CODE: "CF-00009",
-    MESSAGE: "지원하지 않는 형식으로 인코딩된 문자열입니다.",
+    CODE: 'CF-00009',
+    MESSAGE: '지원하지 않는 형식으로 인코딩된 문자열입니다.',
   },
   EMPTY_CLIENT_INFO: {
-    CODE: "CF-00014",
+    CODE: 'CF-00014',
     MESSAGE:
-      "상품 요청을 위해서는 클라이언트 정보가 필요합니다. 클라이언트 아이디와 시크릿 정보를 설정하세요.",
+      '상품 요청을 위해서는 클라이언트 정보가 필요합니다. 클라이언트 아이디와 시크릿 정보를 설정하세요.',
   },
   EMPTY_PUBLIC_KEY: {
-    CODE: "CF-00015",
+    CODE: 'CF-00015',
     MESSAGE:
-      "상품 요청을 위해서는 퍼블릭키가 필요합니다. 퍼블릭키 정보를 설정하세요.",
+      '상품 요청을 위해서는 퍼블릭키가 필요합니다. 퍼블릭키 정보를 설정하세요.',
   },
   BAD_REQUEST: {
-    CODE: "CF-00400",
-    MESSAGE: "클라이언트 요청 오류로 인해 요청을 처리 할 수 ​​없습니다.",
+    CODE: 'CF-00400',
+    MESSAGE: '클라이언트 요청 오류로 인해 요청을 처리 할 수 ​​없습니다.',
   },
   UNAUTHORIZED: {
-    CODE: "CF-00401",
-    MESSAGE: "요청 권한이 없습니다.",
+    CODE: 'CF-00401',
+    MESSAGE: '요청 권한이 없습니다.',
   },
   FORBIDDEN: {
-    CODE: "CF-00403",
-    MESSAGE: "잘못된 요청입니다.",
+    CODE: 'CF-00403',
+    MESSAGE: '잘못된 요청입니다.',
   },
   NOT_FOUND: {
-    CODE: "CF-00404",
-    MESSAGE: "요청하신 페이지(Resource)를 찾을 수 없습니다.",
+    CODE: 'CF-00404',
+    MESSAGE: '요청하신 페이지(Resource)를 찾을 수 없습니다.',
   },
   METHOD_NOT_ALLOWED: {
-    CODE: "CF-00405",
-    MESSAGE: "요청하신 방법(Method)이 잘못되었습니다.",
+    CODE: 'CF-00405',
+    MESSAGE: '요청하신 방법(Method)이 잘못되었습니다.',
   },
   LIBRARY_SENDER_ERROR: {
-    CODE: "CF-09980",
+    CODE: 'CF-09980',
     MESSAGE:
-      "통신 요청에 실패했습니다. 응답정보를 확인하시고 올바른 요청을 시도하세요.",
+      '통신 요청에 실패했습니다. 응답정보를 확인하시고 올바른 요청을 시도하세요.',
   },
   SERVER_ERROR: {
-    CODE: "CF-09999",
-    MESSAGE: "서버 처리중 에러가 발생 했습니다. 관리자에게 문의하세요.",
+    CODE: 'CF-09999',
+    MESSAGE: '서버 처리중 에러가 발생 했습니다. 관리자에게 문의하세요.',
   },
 };
 
-function getResponseMessageConstant(code, message, extraMessage) {
+function getResponseMessageConstant(errorInfo, extraMessage) {
   let result = {
-    code: code,
-    message: message,
-    extraMessage: extraMessage ? extraMessage : "",
+    code: errorInfo.CODE,
+    message: errorInfo.MESSAGE,
+    extraMessage: extraMessage ? extraMessage : '',
   };
-  return { result: result, data: {} };
+  return JSON.stringify({ result: result, data: {} });
 }
 module.exports.getResponseMessageConstant = getResponseMessageConstant;

--- a/lib/properties.js
+++ b/lib/properties.js
@@ -1,14 +1,31 @@
-const easyCodefConstant = require("./constant");
+const {
+  SERVICE_TYPE_API,
+  SERVICE_TYPE_DEMO,
+  API_DOMAIN,
+  SANDBOX_DOMAIN,
+  DEMO_DOMAIN,
+  SANDBOX_CLIENT_ID,
+  SANDBOX_CLIENT_SECRET,
+} = require('./constant');
 
 class EasycodefProperties {
+  constructor() {
+    this.clientID = '';
+    this.clientSecret = '';
+    this.demoClientID = '';
+    this.demoClientSecret = '';
+    this.sandboxClientID = SANDBOX_CLIENT_ID;
+    this.sandboxClientSecret = SANDBOX_CLIENT_SECRET;
+  }
+
   /**
    * 정식서버 사용을 위한 클라이언트 정보 설정
    * @param clientID
    * @param clientSecret
    */
   setClientInfo(clientID, clientSecret) {
-    this.CLIENT_ID = clientID;
-    this.CLIENT_SECRET = clientSecret;
+    this.clientID = clientID;
+    this.clientSecret = clientSecret;
   }
 
   /**
@@ -17,23 +34,23 @@ class EasycodefProperties {
    * @param clientSecret
    */
   setDemoClientInfo(clientID, clientSecret) {
-    this.DEMO_CLIENT_ID = clientID;
-    this.DEMO_CLIENT_SECRET = clientSecret;
+    this.demoClientID = clientID;
+    this.demoClientSecret = clientSecret;
   }
 
   /**
    * 상품 요청 URL
-   * @param productURL
+   * @param productURLPath
    * @returns {string}
    */
-  getProductRequestURL(serviceType, productURL) {
+  getProductRequestURL(serviceType, productURLPath) {
     switch (serviceType) {
-      case easyCodefConstant.SERVICE_TYPE_API:
-        return easyCodefConstant.API_DOMAIN + productURL;
-      case easyCodefConstant.SERVICE_TYPE_DEMO:
-        return easyCodefConstant.DEMO_DOMAIN + productURL;
+      case SERVICE_TYPE_API:
+        return API_DOMAIN + productURLPath;
+      case SERVICE_TYPE_DEMO:
+        return DEMO_DOMAIN + productURLPath;
       default:
-        return easyCodefConstant.SANDBOX_DOMAIN + productURL;
+        return SANDBOX_DOMAIN + productURLPath;
     }
   }
 
@@ -43,6 +60,27 @@ class EasycodefProperties {
    */
   setPublicKey(publicKey) {
     this.PUBLIC_KEY = publicKey;
+  }
+
+  /**
+   * 클라이언트 정보 조회
+   * @param {SERVICE_TYPE} serviceType
+   */
+  getClientInfo(serviceType) {
+    switch (serviceType) {
+      case SERVICE_TYPE_API:
+        return { clientID: this.clientID, clientSecret: this.clientSecret };
+      case SERVICE_TYPE_DEMO:
+        return {
+          clientID: this.demoClientID,
+          clientSecret: this.demoClientSecret,
+        };
+      default:
+        return {
+          clientID: this.sandboxClientID,
+          clientSecret: this.sandboxClientSecret,
+        };
+    }
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "CODEF easyCodef-node",
   "main": "index.js",
   "scripts": {
-    "test": "mocha"
+    "test": "mocha --timeout 10000"
   },
   "repository": {
     "type": "git",

--- a/test/accesstoken.test.js
+++ b/test/accesstoken.test.js
@@ -1,0 +1,26 @@
+const assert = require('assert');
+const AccessToken = require('../lib/accesstoken');
+const {
+  SERVICE_TYPE_SANDBOX,
+  SERVICE_TYPE_DEMO,
+  SERVICE_TYPE_API,
+} = require('../lib/constant');
+
+describe('AccessToken', function () {
+  it('get/set token by service type', function () {
+    const dummyToken = 'hello';
+    const accessToken = new AccessToken();
+
+    // for sandbox
+    accessToken.setToken(SERVICE_TYPE_SANDBOX, dummyToken);
+    assert.equal(dummyToken, accessToken.getToken(SERVICE_TYPE_SANDBOX));
+
+    // for demo
+    accessToken.setToken(SERVICE_TYPE_DEMO, dummyToken);
+    assert.equal(dummyToken, accessToken.getToken(SERVICE_TYPE_DEMO));
+
+    // for api
+    accessToken.setToken(SERVICE_TYPE_API, dummyToken);
+    assert.equal(dummyToken, accessToken.getToken(SERVICE_TYPE_API));
+  });
+});

--- a/test/connector.test.js
+++ b/test/connector.test.js
@@ -1,0 +1,35 @@
+const assert = require('assert');
+const { requestToken, requestProduct, execute } = require('../lib/connector');
+const { SERVICE_TYPE_SANDBOX, CREATE_ACCOUNT } = require('../lib/constant');
+const Easycodef = require('../lib/easycodef');
+const { createParamForCreateConnectedID } = require('./helper');
+
+describe('Connector', function () {
+  it('can request token', async function () {
+    const codef = new Easycodef();
+    const token = await requestToken(SERVICE_TYPE_SANDBOX, codef);
+    assert.ok(!!token);
+  });
+
+  it('can request product', async function () {
+    const codef = new Easycodef();
+    const param = createParamForCreateConnectedID();
+
+    const data = JSON.parse(
+      await requestProduct(SERVICE_TYPE_SANDBOX, `/failPath`, codef, param)
+    );
+
+    assert.equal('CF-00404', data.result.code);
+  });
+
+  it('can execute reuqest', async function () {
+    const codef = new Easycodef();
+    const param = createParamForCreateConnectedID();
+    const data = JSON.parse(
+      await execute(codef, SERVICE_TYPE_SANDBOX, CREATE_ACCOUNT, param)
+    );
+
+    assert.equal('CF-00000', data.result.code);
+    assert.ok(!!data.data.connectedId);
+  });
+});

--- a/test/easycodef.test.js
+++ b/test/easycodef.test.js
@@ -1,0 +1,86 @@
+const assert = require('assert');
+const Easycodef = require('../lib/easycodef');
+const {
+  CREATE_ACCOUNT,
+  SERVICE_TYPE_API,
+  SERVICE_TYPE_SANDBOX,
+  SERVICE_TYPE_DEMO,
+} = require('../lib/constant');
+const { createParamForCreateConnectedID } = require('./helper');
+
+describe('Easycodef', function () {
+  it('can request product', async function () {
+    codef = new Easycodef();
+
+    const param = createParamForCreateConnectedID();
+    // 클라이언트 정보 셋팅하지 않았을때
+    let data = JSON.parse(
+      await codef.requestProduct(CREATE_ACCOUNT, SERVICE_TYPE_API, param)
+    );
+    assert.equal('CF-00014', data.result.code);
+
+    // 데모에 영향을 주었는지 테스트
+    data = JSON.parse(
+      await codef.requestProduct(CREATE_ACCOUNT, SERVICE_TYPE_DEMO, param)
+    );
+    assert.equal('CF-00014', data.result.code);
+
+    // 퍼블릭키 정보 셋팅하지 않았을때
+    codef.setClientInfo('client_id', 'client_secret');
+    data = JSON.parse(
+      await codef.requestProduct(CREATE_ACCOUNT, SERVICE_TYPE_API, param)
+    );
+    assert.equal('CF-00015', data.result.code);
+  });
+
+  it('can sandbox creates account with requestProduct()', async function () {
+    codef = new Easycodef();
+    // 샌드박스 클라이언트 정보는 기본 셋팅 되어 있기 때문에
+    // 퍼블릭 키만 셋팅하면 된다.
+    codef.setPublicKey('public_key');
+
+    const param = createParamForCreateConnectedID();
+    const data = JSON.parse(
+      await codef.requestProduct(CREATE_ACCOUNT, SERVICE_TYPE_SANDBOX, param)
+    );
+
+    assert.equal('CF-00000', data.result.code);
+    assert.ok(!!data.data.connectedId);
+  });
+
+  it('can request token', async function () {
+    codef = new Easycodef();
+    const data = await codef.requestToken(SERVICE_TYPE_SANDBOX);
+    assert.ok(!!data);
+  });
+
+  it('can get cid list', async function () {
+    codef = new Easycodef();
+    codef.setPublicKey('public_key');
+    const param = createParamForCreateConnectedID();
+    const data = JSON.parse(
+      await codef.getConnectedIdList(SERVICE_TYPE_SANDBOX, param)
+    );
+    assert.ok(data.data.connectedIdList.length > 0);
+  });
+
+  it('can create account', async function () {
+    codef = new Easycodef();
+    codef.setPublicKey('public_key');
+    const param = createParamForCreateConnectedID();
+    const data = JSON.parse(
+      await codef.createAccount(SERVICE_TYPE_SANDBOX, param)
+    );
+    assert.ok(!!data.data.connectedId);
+  });
+
+  it('can get account list', async function () {
+    codef = new Easycodef();
+    codef.setPublicKey('public_key');
+    const param = createParamForCreateConnectedID();
+    const data = JSON.parse(
+      await codef.getAccountList(SERVICE_TYPE_SANDBOX, param)
+    );
+    assert.ok(data.data.accountList.length > 0);
+  });
+});

--- a/test/helper.js
+++ b/test/helper.js
@@ -1,0 +1,37 @@
+const { encryptRSA } = require('../lib/util');
+
+function createParamForCreateConnectedID() {
+  const publicKey =
+    'MIIBIjANBgkqhkiG9w0BAQ' +
+    'EFAAOCAQ8AMIIBCgKCAQEAuhRrVDeMf' +
+    'b2fBaf8WmtGcQ23Cie+qDQqnkKG9eZV' +
+    'yJdEvP1rLca+0CUOuAnpE8yGPY3HEbd' +
+    'xKTsbIxxV9H8DCEMntXq2VP4loQoYUl' +
+    '0h9dTjtBVWvhYev0s7N5B8Qu9LtykE2' +
+    'k9KBuSZ+5dXulnHYdYjBaifZL6pzoD1' +
+    'ckXoa4TtIuPjZZGXzr3Ivt5LDxPoPfw' +
+    '1qMdqWRF9/YQSK1jZYa7PNR1Hbd8KB8' +
+    '85VEcXNRU7ADHSgdYRBYB8apsPwaChy' +
+    'jgrV98ATLOD7Dl4RlPtXcx/vEKjVMdt' +
+    'CqJ2IHKeJoUCzBPY59U/mtIhjPuQmwS' +
+    'MLEnLisDWEZMkenO0xJbwOwIDAQAB';
+
+  const password = encryptRSA(publicKey, 'password');
+  return {
+    accountList: [
+      {
+        countryCode: 'KR',
+        businessType: 'BK',
+        clientType: 'P',
+        organization: '0004',
+        loginType: '1',
+        id: 'testID',
+        password: password,
+      },
+    ],
+  };
+}
+
+module.exports = {
+  createParamForCreateConnectedID,
+};


### PR DESCRIPTION
- 리팩토링 진행
- 리팩토링 진행하면서 테스트 코드 추가
- accesstoken, properties 인스턴스 easycodef 인스턴스 내부에서 생성하여
  멤버 변수로 관리. 이렇게 해야 여러개 인스턴스 사용시 안전함.
- easycodef 메소드에서 비동기 함수를 호출하는 메소드는 async 키워드 부여
- 요청 반환 값 스트링 타입으로 통일 (에러 정보의 경우 객체로 반환되는
    케이스가 존재했음)