### PR TITLE
2Way check 개선

### DIFF
--- a/lib/easycodef.ts
+++ b/lib/easycodef.ts
@@ -248,8 +248,8 @@ function hasTwoWayInfo(param: any): boolean {
  */
 function hasNeedValueInTwoWayInfo(twoWayInfo: any): boolean {
   return (
-    twoWayInfo.jobIndex &&
-    twoWayInfo.threadIndex &&
+    (twoWayInfo.jobIndex === 0 || twoWayInfo.jobIndex) &&
+    (twoWayInfo.threadIndex === 0 || twoWayInfo.threadIndex) &&
     twoWayInfo.jti &&
     twoWayInfo.twoWayTimestamp
   );


### PR DESCRIPTION
twoWayInfo의 jobIndex와 threadIndex 값은 0이 될 수 있기 때문에
0일 경우 true로 평가될 수 있도록 개선.

( Fixed #8 )